### PR TITLE
feat: Store and manage system prompts in database

### DIFF
--- a/schema/04_system_prompts.sql
+++ b/schema/04_system_prompts.sql
@@ -1,0 +1,23 @@
+-- Migration for system_prompts table
+
+CREATE TABLE system_prompts (
+    id SERIAL PRIMARY KEY,
+    prompt_type VARCHAR(50) UNIQUE NOT NULL,
+    content TEXT NOT NULL,
+    last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Function to update last_modified timestamp on row update
+CREATE OR REPLACE FUNCTION update_last_modified_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.last_modified = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Trigger to update last_modified on system_prompts table update
+CREATE TRIGGER update_system_prompts_last_modified
+BEFORE UPDATE ON system_prompts
+FOR EACH ROW
+EXECUTE FUNCTION update_last_modified_column();

--- a/templates/admin_actions.html
+++ b/templates/admin_actions.html
@@ -16,6 +16,9 @@
         <a href="{{ url_for('upload_file') }}" class="block w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
             Upload JSONL File
         </a>
+        <a href="{{ url_for('manage_system_prompts_view') }}" class="block w-full bg-teal-600 hover:bg-teal-700 text-white font-bold py-2 px-4 rounded-md text-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500">
+            Manage System Prompts
+        </a>
     </div>
 </div>
 {% endblock %}

--- a/templates/manage_system_prompts.html
+++ b/templates/manage_system_prompts.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Manage System Prompts{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto bg-white shadow-lg rounded-lg p-8">
+    <h2 class="text-2xl font-bold text-gray-800 mb-6">Manage System Prompts</h2>
+    
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="p-4 mb-4 text-sm text-{{ 'green' if category == 'success' else 'red' }}-700 bg-{{ 'green' if category == 'success' else 'red' }}-100 rounded-lg" role="alert">
+            {{ message }}
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    {% for prompt in prompts %}
+    <div class="mb-8 p-6 border border-gray-200 rounded-lg">
+        <h3 class="text-xl font-semibold text-gray-700 mb-3">{{ prompt.prompt_type | capitalize }}</h3>
+        <form method="POST" action="{{ url_for('update_system_prompt_action') }}">
+            <input type="hidden" name="prompt_type" value="{{ prompt.prompt_type }}">
+            <div class="mb-4">
+                <label for="content-{{ prompt.prompt_type }}" class="block text-sm font-medium text-gray-700">Prompt Content:</label>
+                <textarea name="content" id="content-{{ prompt.prompt_type }}" rows="15" class="mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">{{ prompt.content }}</textarea>
+            </div>
+            <button type="submit" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                Save Changes for {{ prompt.prompt_type | capitalize }}
+            </button>
+        </form>
+    </div>
+    {% else %}
+    <p class="text-gray-600">No system prompts found in the database.</p>
+    {% endfor %}
+    <div class="mt-6">
+        <a href="{{ url_for('admin_actions') }}" class="text-indigo-600 hover:text-indigo-900">&larr; Back to Admin Actions</a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This change introduces the ability for administrators to manage system prompts (for Chat UI and WhatsApp) via the web application's UI.

Key changes:
- Added a new `system_prompts` table to the database to store prompt content and type.
- Implemented a seeding mechanism to populate initial prompts from existing hardcoded versions into the database on application startup.
- Modified the application to load prompts from the database, with fallbacks to hardcoded defaults if a prompt is not found in the DB.
- Created new admin-only routes and a corresponding HTML template (`/admin/system_prompts`) for viewing and editing these prompts.
- Linked the new management page from the existing admin actions page.
- Ensured RAG context (`{rag_context}`) placeholder is handled correctly with database-sourced prompts.

This allows for easier modification of system prompts without requiring code changes and redeployments.